### PR TITLE
bump elm version to 0.19.1

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:8
-RUN npm install -g elm-github-install create-elm-app@3.0.6 --unsafe-perm=true
+RUN npm install -g elm-github-install create-elm-app@5.22.0 --unsafe-perm=true
 WORKDIR /source
 CMD elm-app build

--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -1,4 +1,4 @@
 .PHONY: run
 
 build:
-	docker build . -t infomark/elm:0.19.0
+	docker build . -t infomark/elm:0.19.1

--- a/.github/workflows/elm.yml
+++ b/.github/workflows/elm.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: infomark/elm:0.19.0
+      image: infomark/elm:0.19.1
 
     steps:
       - uses: actions/checkout@v1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: build
 
 build:
-	docker run -it -v `pwd`:/source -v `pwd`/.cache:/root/.elm -u $(id -u ${USER}):$(id -g ${USER}) infomark/elm:0.19.0
+	docker run -it -v `pwd`:/source -v `pwd`/.cache:/root/.elm -u $(id -u ${USER}):$(id -g ${USER}) infomark/elm:0.19.1

--- a/elm.json
+++ b/elm.json
@@ -4,7 +4,7 @@
         "src",
         "elm-mdc/src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "CurrySoftware/elm-datepicker": "3.0.1",

--- a/src/Routing/Router.elm
+++ b/src/Routing/Router.elm
@@ -1,4 +1,4 @@
-port module Routing.Router exposing (CurrentModel(..), Model, Msg(..), footerView, getTranslations, init, initWith, navView, navigateTo, noTabPage, pageView, tabPage, update, updateWith, view)
+module Routing.Router exposing (CurrentModel(..), Model, Msg(..), footerView, getTranslations, init, initWith, navView, navigateTo, noTabPage, pageView, tabPage, update, updateWith, view)
 
 --(Model, Msg(..), init, pageView, update, updateHome, updateSettings, view)
 


### PR DESCRIPTION
Using ELM 0.19.1 one can compile as follows:

```bash
# make sure to pull elm-mdc submodule
git submodule update --init --recursive

# install the build system (this will create a folder node_modules)
npm install https://github.com/halfzebra/create-elm-app

# build the frontend
export PATH="./node_modules/create-elm-app/bin:${PATH}"
export PATH="./node_modules/elm/bin:${PATH}"
export PATH="./node_modules/uglify-es/bin:${PATH}"
elm-app-cli.js build
./optimize.sh src/Main.elm
```

might be nicer than the ELM 0.19.0 workaround.