### PR TITLE
Set the group bid default to 10

### DIFF
--- a/src/Components/Groups/BiddingView.elm
+++ b/src/Components/Groups/BiddingView.elm
@@ -314,7 +314,7 @@ viewGroupBid sharedState model data =
                     group.tutor
 
                 curBid =
-                    Maybe.withDefault 1 data.bid
+                    Maybe.withDefault 10 data.bid
             in
             div [ classes [ TC.w_100, TC.ph2 ] ] <|
                 [ h3 [ Styles.listHeadingStyle ]


### PR DESCRIPTION
match the backend's default when creating the data for assignment optimization:
https://github.com/infomark-org/infomark/blob/9f94c21fca737acec5aa0a0192b42e02997f32fc/cmd/console/group_cmd.go#L356

see also:
https://github.com/infomark-org/infomark/commit/e7618817a89897365319a61dbdf382caa26e1e88
(this would change the backend instead)